### PR TITLE
registry: avoid locking subscriber callbacks

### DIFF
--- a/doc.go
+++ b/doc.go
@@ -43,9 +43,10 @@
 //
 //	client.Nodes(opts)
 //
-// Subscribe to changes in a set of nodes:
+// Subscribe to changes in the registry. The callback will fire whenever the
+// registry is updated.
 //
-//	client.Subscribe(callback, opts)
+//	client.Subscribe(callback)
 //
 // Note when subscribing the callback will fire immediately with the matching
 // cluster state, so theres no need to call Nodes first.
@@ -82,9 +83,6 @@
 //
 //	// Lookup the set of nodes matching the filter.
 //	client.Nodes(fuddle.WithFilter(filter))
-//
-//	// Subscribe to updates in the set of nodes matching the filter.
-//	client.Subscribe(callback, fuddle.WithFilter(filter))
 //
 // # Register
 //

--- a/fuddle.go
+++ b/fuddle.go
@@ -103,14 +103,10 @@ func (f *Fuddle) Nodes(opts ...Option) []Node {
 // Subscribe registers the given callback to fire when the registry state
 // changes.
 //
-// The callback will be called immediately after registering with the current
-// node state.
-//
-// Note the callback is called synchronously with the registry mutex held,
-// therefore it must NOT block or callback to the registry (or it will
-// deadlock).
-func (f *Fuddle) Subscribe(cb func(nodes []Node), opts ...Option) func() {
-	return f.registry.Subscribe(cb, opts...)
+// The callback will be called immediately after registering to bootstrap
+// the caller.
+func (f *Fuddle) Subscribe(cb func()) func() {
+	return f.registry.Subscribe(cb)
 }
 
 // Register registers the given node and returns a reference to the node so

--- a/fuddle_integration_test.go
+++ b/fuddle_integration_test.go
@@ -92,12 +92,12 @@ func waitForNode(client *Fuddle, id string) (Node, error) {
 	var node Node
 	found := false
 	recvCh := make(chan interface{})
-	unsubscribe := client.Subscribe(func(nodes []Node) {
+	unsubscribe := client.Subscribe(func() {
 		if found {
 			return
 		}
 
-		for _, n := range nodes {
+		for _, n := range client.Nodes() {
 			if n.ID == id {
 				found = true
 				node = n
@@ -117,12 +117,12 @@ func waitForNode(client *Fuddle, id string) (Node, error) {
 func waitForCount(client *Fuddle, count int) error {
 	found := false
 	recvCh := make(chan interface{})
-	unsubscribe := client.Subscribe(func(nodes []Node) {
+	unsubscribe := client.Subscribe(func() {
 		if found {
 			return
 		}
 
-		if len(nodes) == count {
+		if len(client.Nodes()) == count {
 			found = true
 			close(recvCh)
 			return

--- a/fuddle_test.go
+++ b/fuddle_test.go
@@ -126,13 +126,13 @@ func Example_subscribeToOrdersServiceNodes() {
 	// Filter to only include order service nodes in us-east-1 whose status
 	// is active and protocol version is either 2 or 3.
 	var addrs []string
-	client.Subscribe(func(orderNodes []fuddle.Node) {
+	client.Subscribe(func() {
 		addrs = nil
-		for _, node := range orderNodes {
+		for _, node := range client.Nodes(fuddle.WithFilter(filter)) {
 			addr := node.Metadata["addr.rpc.ip"] + ":" + node.Metadata["addr.rpc.port"]
 			addrs = append(addrs, addr)
 		}
 
 		fmt.Println("order service:", addrs)
-	}, fuddle.WithFilter(filter))
+	})
 }


### PR DESCRIPTION
Avoids locking the registry mutex when calling the subscribers. This means ordering is undefined, therefore no longer includes any state in the callback. The user can instead simply query the registry again to get the updated state.